### PR TITLE
Remove PHP 5.6 as an option. PHP 5.6 support was removed in Laravel 5.5

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -364,12 +364,12 @@ After running the command, you will see an Ngrok screen appear which contains th
 
 > {note} This feature is only compatible with Nginx.
 
-Homestead 6 introduced support for multiple versions of PHP on the same virtual machine. You may specify which version of PHP to use for a given site within your `Homestead.yaml` file. The available PHP versions are: "5.6", "7.0", and "7.1":
+Homestead 6 introduced support for multiple versions of PHP on the same virtual machine. You may specify which version of PHP to use for a given site within your `Homestead.yaml` file. The available PHP versions are: "7.0", and "7.1" (support for PHP 5.6 was removed in Laravel 5.5):
 
     sites:
         - map: homestead.app
           to: /home/vagrant/Code/Laravel/public
-          php: "5.6"
+          php: "7.0"
 
 In addition, you may use any of the supported PHP versions via the CLI:
 


### PR DESCRIPTION
PHP 5.6 support was removed in Laravel 5.5
See https://laravel-news.com/laravel-5-5-php-7-0